### PR TITLE
fix mime-type error

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,6 +8,7 @@ events {
 }
 
 http {
+  include    /etc/nginx/mime.types;
   access_log /dev/stdout;
   server_tokens off; # Hide nginx version in Server header & page footers
 


### PR DESCRIPTION
Fix `Refused to execute script from '<URL>' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.`